### PR TITLE
Init direnv and pre-commit hooks

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+use_flake
+
+watch_file .pre-commit-config.yaml
+pre-commit install

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Godot 4+ specific ignores
 .godot/
+
+.direnv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: mixed-line-ending
+        args: ['--fix=lf']
+    -   id: check-merge-conflict
+    -   id: check-case-conflict
+-   repo: https://github.com/Scony/godot-gdscript-toolkit
+    rev: 4.0.1
+    hooks:
+    -   id: gdformat
+        exclude: ^addons|tests/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "meptlpkgs": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1682633407,
+        "narHash": "sha256-CoRAi/N1IUMXcD9sU8XnbTZc8D2Wtury+K0LY/K4ZDo=",
+        "owner": "Meptl",
+        "repo": "meptlpkgs",
+        "rev": "93887a57edf366daaaec1a51f7ced479eb060926",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "Meptl",
+        "repo": "meptlpkgs",
+        "type": "gitlab"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1681713375,
+        "narHash": "sha256-UPDEwrzOQLTNzNDMkcf3J7+7vV3zlQCCrO33kwlFsdY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9a60b3eef1a0ccb4e3459eba1814bae91d07134e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1682566018,
+        "narHash": "sha256-HPzPRFiy2o/7k7mtnwfM1E6NVZHiFbPdmYCMoIpkHO4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8e3b64db39f2aaa14b35ee5376bd6a2e707cadc2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "meptlpkgs": "meptlpkgs",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "";
+
+  inputs = {
+    meptlpkgs.url = "gitlab:Meptl/meptlpkgs";
+  };
+
+  outputs = { self, nixpkgs, meptlpkgs }:
+  let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {
+      inherit system;
+      config.allowUnfree = true;
+    };
+  in
+  {
+    devShell.${system} = pkgs.mkShell {
+      buildInputs = with pkgs; [
+        pre-commit
+
+        # Custom gdtoolkit 4.0 build.
+        meptlpkgs.packages.${system}.gdtoolkit
+      ];
+    };
+  };
+}


### PR DESCRIPTION
Init flake.nix
Uses direnv to automatically load flake.nix (and pre-commit).
Uses pre-commit to install a set of git pre-commit hooks. Noteably to:
- fix mixed line endings
- Run gdformat on all committed gdscript files

The backing binary for the gd formatter wasn't in nixpkgs so I'm pointing to [my own package definition](https://gitlab.com/Meptl/meptlpkgs/-/blob/main/packages/gdtoolkit/default.nix) for now. 