### PR TITLE
Remove '.import' files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Godot 4+ specific ignores
 .godot/
-
+*.import
 .direnv


### PR DESCRIPTION
Gets rid of `.import` files that godot uses